### PR TITLE
Fixes NPE for Drag and Drop feature in Contentfinder

### DIFF
--- a/slice-core/src/main/java/com/cognifide/slice/core/internal/provider/SliceModelClassResolver.java
+++ b/slice-core/src/main/java/com/cognifide/slice/core/internal/provider/SliceModelClassResolver.java
@@ -80,7 +80,10 @@ public class SliceModelClassResolver implements ModelClassResolver {
 			resolver = resourceResolverFactory.getAdministrativeResourceResolver(null);
 			final Resource componentDefinition = resolver.getResource(resourceType);
 			if (componentDefinition != null) {
-				return new HashMap<String, Object>(componentDefinition.adaptTo(ValueMap.class));
+				Map<String, Object> values = componentDefinition.adaptTo(ValueMap.class);
+				if (values!=null) {
+					return new HashMap<String, Object>(values);
+				}
 			}
 			return null;
 		} catch (LoginException e) {

--- a/slice-core/src/main/java/com/cognifide/slice/core/internal/provider/SliceModelClassResolver.java
+++ b/slice-core/src/main/java/com/cognifide/slice/core/internal/provider/SliceModelClassResolver.java
@@ -81,7 +81,7 @@ public class SliceModelClassResolver implements ModelClassResolver {
 			final Resource componentDefinition = resolver.getResource(resourceType);
 			if (componentDefinition != null) {
 				Map<String, Object> values = componentDefinition.adaptTo(ValueMap.class);
-				if (values!=null) {
+				if (values != null) {
 					return new HashMap<String, Object>(values);
 				}
 			}


### PR DESCRIPTION
Fixes NPE in cases where resource.adaptTo(ValueMap.class) returns null value (i.e. when underlying resource is a SyntheticResource).

We had this NPE issue when using the drag and drop feature in the (classic) Contentfinder and were dragging images to DropTargets in our page.